### PR TITLE
Сборка с динамическим boost как опция (USE_STATIC_BOOST)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,13 @@ set(CMAKE_CXX_STANDARD 14)
 add_executable (v8unpack ${V8UNPACK_SOURCES} ${V8UNPACK_HEADERS} ${RC_FILE})
 
 add_definitions (-DBOOST_ALL_NO_LIB)
-set (Boost_USE_STATIC_LIBS ON)
-set (Boost_USE_MULTITHREADED OFF)
-set (Boost_USE_STATIC_RUNTIME ON)
+
+option(USE_STATIC_BOOST "Link against static boost libraries" ON)
+if(USE_STATIC_BOOST)
+	set (Boost_USE_STATIC_LIBS ON)
+	set (Boost_USE_MULTITHREADED OFF)
+	set (Boost_USE_STATIC_RUNTIME ON)
+endif()
 
 find_package (Boost 1.53 REQUIRED COMPONENTS filesystem system iostreams)
 


### PR DESCRIPTION
## Проблема

В `CMakeLists.txt` жёстко включены статический boost и static-runtime:

```cmake
set (Boost_USE_STATIC_LIBS ON)
set (Boost_USE_MULTITHREADED OFF)
set (Boost_USE_STATIC_RUNTIME ON)
```

На Debian/Ubuntu (пакеты `libboost-*-dev`) сборка падает на `find_package(Boost)`:

```
No suitable build variant has been found.
  * libboost_filesystem.so.1.74.0 (shared, Boost_USE_STATIC_LIBS=ON)
  * libboost_filesystem.a (shared runtime, Boost_USE_STATIC_RUNTIME=ON)
```

— в дистрибутивных пакетах boost не собран со static runtime.

## Решение

Статический boost становится опцией (по умолчанию включён — поведение
существующих сборок не меняется):

```cmake
option(USE_STATIC_BOOST "Link against static boost libraries" ON)
if(USE_STATIC_BOOST)
    ...
endif()
```

Для сборки с динамическим boost: `cmake -DUSE_STATIC_BOOST=OFF ..`

## Проверка

`debian:bookworm-slim` + `cmake make g++ libboost-filesystem-dev
libboost-iostreams-dev libboost-system-dev zlib1g-dev`:

```
cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_STATIC_BOOST=OFF && make -j$(nproc)
```

— собирается без ошибок; round-trip `v8unpack -P/-B` на реальном `.erf`
проверен (распаковка пересобранного бинарника байт-в-байт совпадает).

Используется таким образом в Docker-образе конвертера (проект convert2edt),
где сейчас ради этого применяется sed по CMakeLists.txt — с мерджем PR
удалим sed.
